### PR TITLE
Fixing Segfault for Py >= 3.10 due to PY_SSIZE_T_CLEAN

### DIFF
--- a/netsnmp/client_intf.c
+++ b/netsnmp/client_intf.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <net-snmp/net-snmp-config.h>


### PR DESCRIPTION
When using `s#` formats with `Py_BuildValue`,
since 3.10 PY_SSIZE_T_CLEAN has to be defined before including `Python.h`. Otherwise `Py_BuildValue` returns `0` which results in Segfault.

See https://bugs.python.org/issue36381