### PR TITLE
Prepare 1.1a2 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ incdirs = []
 libs = re.findall(r" -l(\S+)", netsnmp_libs)
 
 setup(
-    name="python3-netsnmp", version="1.1a1",
+    name="python3-netsnmp", version="1.1a2",
     description = 'The Net-SNMP Python Interface',
     long_description = '''
 Python3 port of the official Net-SNMP Python bindings.


### PR DESCRIPTION
## Summary

- Bump the package version from `1.1a1` to `1.1a2` so the fix merged in #12 can be published.

## Context

PyPI currently provides only `1.1a1`, which predates the `PY_SSIZE_T_CLEAN` correction already present on
`master`.

This PR prepares the package metadata and source distribution. Tagging and publishing to PyPI remain post-merge
release steps.

Refs #13.

## Validation

- Python 3.12.10 with setuptools 83.0.0: `setup.py --version` returned `1.1a2`.
- Python 3.12.10: `setup.py sdist` produced `python3_netsnmp-1.1a2.tar.gz`.
- Python 3.14.3: the same version and sdist checks passed.

The native integration tests were not run locally because they require Net-SNMP libraries and a configured local
`snmpd`. Issue #13 records the Python 3.12 reproduction and verification of the correction already merged in #12.
