### PR TITLE
Honor RemotePort for SNMP sessions

### DIFF
--- a/netsnmp/client.py
+++ b/netsnmp/client.py
@@ -140,6 +140,9 @@ class Session(object):
         # check for transports that may be tunneled
         transportCheck = re.compile('^(tls|dtls|ssh)');
         match = transportCheck.match(sess_args['DestHost'])
+        peer = sess_args['DestHost']
+        if not match and sess_args['RemotePort'] != 161:
+            peer = '{}:{}'.format(peer, sess_args['RemotePort'])
 
         err = None
 
@@ -163,7 +166,7 @@ class Session(object):
             elif sess_args['Version'] == 3:
                 self.sess_ptr = client_intf.session_v3(
                     sess_args['Version'],
-                    sess_args['DestHost'],
+                    peer,
                     sess_args['LocalPort'],
                     sess_args['Retries'],
                     sess_args['Timeout'],
@@ -182,7 +185,7 @@ class Session(object):
                 self.sess_ptr = client_intf.session(
                     sess_args['Version'],
                     sess_args['Community'],
-                    sess_args['DestHost'],
+                    peer,
                     sess_args['LocalPort'],
                     sess_args['Retries'],
                     sess_args['Timeout'])

--- a/netsnmp/tests/system/test_remote_port.py
+++ b/netsnmp/tests/system/test_remote_port.py
@@ -1,0 +1,45 @@
+import socket
+import unittest
+
+import netsnmp
+
+
+class RemotePortTests(unittest.TestCase):
+    def assert_request_received(
+            self, version, dest_host, use_remote_port=False):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as listener:
+            listener.bind(('127.0.0.1', 0))
+            listener.settimeout(1)
+            port = listener.getsockname()[1]
+            session_args = {
+                'Version': version,
+                'DestHost': dest_host.format(port=port),
+                'Community': 'public',
+                'Timeout': 1000,
+                'Retries': 0,
+            }
+            if use_remote_port:
+                session_args['RemotePort'] = port
+            session = netsnmp.Session(**session_args)
+            varlist = netsnmp.VarList(
+                netsnmp.Varbind('.1.3.6.1.2.1.1.1', '0'))
+
+            session.get(varlist)
+            request, _ = listener.recvfrom(65535)
+            self.assertTrue(request)
+
+    def test_remote_port_selects_destination_port(self):
+        for version in (1, 2, 3):
+            with self.subTest(version=version):
+                self.assert_request_received(
+                    version, '127.0.0.1', use_remote_port=True)
+
+    def test_dest_host_port_remains_supported(self):
+        for version in (1, 2, 3):
+            with self.subTest(version=version):
+                self.assert_request_received(
+                    version, '127.0.0.1:{port}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #4 by making the `RemotePort` session parameter control the destination UDP port used for SNMP requests.

## Root Cause

`RemotePort` was parsed and stored on the Python `Session` object, but it was never passed to the native session constructors. As a result, requests continued to use the default SNMP port 161.

Net-SNMP no longer uses its native `remote_port` session field. The supported method is to include the destination port in the peer name.

## Changes

- Append a non-default `RemotePort` to the native UDP peer name.
- Apply the peer name to SNMP v1, v2c, and v3 UDP sessions.
- Leave tunneled TLS, DTLS, and SSH transports unchanged.
- Preserve support for the existing `DestHost="host:port"` syntax.
- Add packet-level regression tests using an ephemeral UDP listener.

## Testing

- Built the native extension on Fedora 43 with Python 3.14 and Net-SNMP 5.9.4.
- Verified that `RemotePort` sends the SNMP request to the selected port.
- Verified that the existing `DestHost="host:port"` syntax continues to work.
- Confirmed both regression tests pass.