### PR TITLE
Prevent crashes on bare Varbind arguments

### DIFF
--- a/netsnmp/client_intf.c
+++ b/netsnmp/client_intf.c
@@ -1535,8 +1535,12 @@ netsnmp_get(PyObject *self, PyObject *args)
 
     if (varlist) {
       PyObject *varlist_iter = PyObject_GetIter(varlist);
+      if (!varlist_iter) {
+        snmp_free_pdu(pdu);
+        goto done;
+      }
 
-      while (varlist_iter && (varbind = PyIter_Next(varlist_iter))) {
+      while ((varbind = PyIter_Next(varlist_iter))) {
         if (py_netsnmp_attr_string(varbind, "tag", &tag, NULL) < 0 ||
             py_netsnmp_attr_string(varbind, "iid", &iid, NULL) < 0)
         {
@@ -1682,6 +1686,10 @@ netsnmp_get(PyObject *self, PyObject *args)
 
 done:
   SAFE_FREE(oid_arr);
+  if (PyErr_Occurred()) {
+    Py_XDECREF(val_tuple);
+    return NULL;
+  }
   return (val_tuple ? val_tuple : Py_BuildValue(""));
 }
 
@@ -1753,8 +1761,12 @@ netsnmp_getnext(PyObject *self, PyObject *args)
 
     if (varlist) {
       PyObject *varlist_iter = PyObject_GetIter(varlist);
+      if (!varlist_iter) {
+        snmp_free_pdu(pdu);
+        goto done;
+      }
 
-      while (varlist_iter && (varbind = PyIter_Next(varlist_iter))) {
+      while ((varbind = PyIter_Next(varlist_iter))) {
         if (py_netsnmp_attr_string(varbind, "tag", &tag, NULL) < 0 ||
             py_netsnmp_attr_string(varbind, "iid", &iid, NULL) < 0)
         {
@@ -1902,6 +1914,10 @@ netsnmp_getnext(PyObject *self, PyObject *args)
 
 done:
   SAFE_FREE(oid_arr);
+  if (PyErr_Occurred()) {
+    Py_XDECREF(val_tuple);
+    return NULL;
+  }
   return (val_tuple ? val_tuple : Py_BuildValue(""));
 }
 
@@ -1991,8 +2007,12 @@ netsnmp_walk(PyObject *self, PyObject *args)
 
     /* we need an initial count for memory allocation */
     varlist_iter = PyObject_GetIter(varlist);
+    if (!varlist_iter) {
+      snmp_free_pdu(pdu);
+      goto done;
+    }
     varlist_len = 0;
-    while (varlist_iter && (varbind = PyIter_Next(varlist_iter))) {
+    while ((varbind = PyIter_Next(varlist_iter))) {
       varlist_len++;
     }
     Py_DECREF(varlist_iter);
@@ -2523,14 +2543,16 @@ netsnmp_getbulk(PyObject *self, PyObject *args)
       /* propagate error */
       if (verbose)
         printf("error: getbulk response processing: unknown python error");
-      if (val_tuple)
-        Py_DECREF(val_tuple);
-      val_tuple = NULL;
+      Py_CLEAR(val_tuple);
     }
   }
 
 done:
   SAFE_FREE(oid_arr);
+  if (PyErr_Occurred()) {
+    Py_XDECREF(val_tuple);
+    return NULL;
+  }
   return (val_tuple ? val_tuple : Py_BuildValue(""));
 }
 
@@ -2539,7 +2561,7 @@ netsnmp_set(PyObject *self, PyObject *args)
 {
   PyObject *session;
   PyObject *varlist;
-  PyObject *varbind;
+  PyObject *varbind = NULL;
   PyObject *ret = NULL;
   netsnmp_session *ss;
   netsnmp_pdu *pdu, *response;
@@ -2587,8 +2609,12 @@ netsnmp_set(PyObject *self, PyObject *args)
 
     if (varlist) {
       PyObject *varlist_iter = PyObject_GetIter(varlist);
+      if (!varlist_iter) {
+        snmp_free_pdu(pdu);
+        goto done;
+      }
 
-      while (varlist_iter && (varbind = PyIter_Next(varlist_iter))) {
+      while ((varbind = PyIter_Next(varlist_iter))) {
         if (py_netsnmp_attr_string(varbind, "tag", &tag, NULL) < 0 ||
             py_netsnmp_attr_string(varbind, "iid", &iid, NULL) < 0)
         {
@@ -2673,6 +2699,8 @@ netsnmp_set(PyObject *self, PyObject *args)
 done:
   Py_XDECREF(varbind); 
   SAFE_FREE(oid_arr);
+  if (PyErr_Occurred())
+    return NULL;
   return (ret ? ret : Py_BuildValue(""));
 }
 

--- a/netsnmp/tests/system/test_errors.py
+++ b/netsnmp/tests/system/test_errors.py
@@ -6,6 +6,23 @@ from netsnmp.tests.system.common import READ_ARGS, SYS_DESCR, SYS_LOCATION
 
 
 class ErrorPathTests(unittest.TestCase):
+    def test_session_methods_reject_bare_varbind(self):
+        session = netsnmp.Session(**READ_ARGS)
+        varbind = netsnmp.Varbind(
+            '.1.3.6.1.2.1.1.3', '0', b'1', 'INTEGER')
+        calls = (
+            (TypeError, lambda: session.get(varbind)),
+            (TypeError, lambda: session.getnext(varbind)),
+            (TypeError, lambda: session.set(varbind)),
+            (AttributeError, lambda: session.walk(varbind)),
+            (AttributeError, lambda: session.getbulk(0, 1, varbind)),
+        )
+
+        for error_type, call in calls:
+            with self.subTest(call=call):
+                with self.assertRaises(error_type):
+                    call()
+
     def test_unknown_oid_returns_no_value(self):
         varbind = netsnmp.Varbind('.1.3.6.1.2.1.1.999', '0')
         values = netsnmp.snmpget(varbind, **READ_ARGS)


### PR DESCRIPTION
## Summary

Fixes #5 by preventing interpreter crashes when a bare `Varbind` is passed to session methods that require a `VarList`.

Invalid arguments now produce direct Python exceptions instead of segmentation faults or secondary `SystemError` exceptions.

## Root Cause

The native extension called `PyObject_GetIter()` but did not check whether iterator creation succeeded.

When a bare, non-iterable `Varbind` was supplied, iterator creation returned `NULL` and set a Python exception. Several methods then passed the null pointer to another API or decremented its reference count, causing a segmentation fault.

Other methods returned a value while an exception was still active, which Python reported as a `SystemError`.

## Changes

- Check that iterator acquisition succeeds before using or releasing the iterator.
- Return `NULL` from native methods when a Python exception is active.
- Initialize cleanup references before use.
- Prevent double decrements on response-processing error paths.
- Apply the safety checks to:
  - `get`
  - `getnext`
  - `set`
  - `walk`
  - `getbulk`
- Add regression coverage for all five methods.

## Behavior

Before this change:

- `get`, `getnext`, and `set` terminated the interpreter with `SIGSEGV`.
- `walk` and `getbulk` raised `SystemError`.

After this change:

- `get`, `getnext`, and `set` raise `TypeError`.
- `walk` and `getbulk` raise `AttributeError`.

## Testing

- Built the native extension on Fedora 43 with Python 3.14 and Net-SNMP 5.9.4.
- Ran the focused five-method regression test.
- Verified each method in an isolated subprocess.
- Confirmed no method crashes the interpreter.
- Confirmed the native C file has no diagnostics.
- Confirmed the patch passes the whitespace check.