### PR TITLE
ci: upgrade checkout action to v7

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2


### PR DESCRIPTION
## Summary

Upgrade all GitHub Actions checkout steps from `actions/checkout@v4` to `actions/checkout@v7`.

This removes the Node.js 20 deprecation warning and moves the workflows to the latest stable checkout major version.

## Changes

- Upgrade the three checkout steps in the Linux system-test workflow.
- Upgrade the checkout step in the Windows workflow.
- No workflow behavior or job configuration changes.

## Validation

- Parsed both workflow files as valid YAML.
- Confirmed no older `actions/checkout` references remain.
- `git diff --check` passes.