### PR TITLE
Fix missing SNMPv1 instance values

### DIFF
--- a/netsnmp/client_intf.c
+++ b/netsnmp/client_intf.c
@@ -1619,6 +1619,9 @@ netsnmp_get(PyObject *self, PyObject *args)
         vars && (varlist_ind < varlist_len);
         vars = vars->next_variable, varlist_ind++) {
 
+      if (err_ind >= 1 && varlist_ind >= err_ind - 1)
+        continue;
+
       varbind = PySequence_GetItem(varlist, varlist_ind);
 
       if (PyObject_HasAttrString(varbind, "tag")) {

--- a/netsnmp/tests/system/test_errors.py
+++ b/netsnmp/tests/system/test_errors.py
@@ -13,6 +13,12 @@ class ErrorPathTests(unittest.TestCase):
         self.assertEqual(values, (None,))
         self.assertIn(varbind.type, ('NOSUCHOBJECT', 'NOSUCHINSTANCE'))
 
+    def test_unknown_instance_returns_no_value(self):
+        varbind = netsnmp.Varbind(SYS_DESCR, '123')
+
+        self.assertEqual(netsnmp.snmpget(varbind, **READ_ARGS), (None,))
+        self.assertEqual(varbind.type, 'NOSUCHINSTANCE')
+
     def test_read_only_set_is_rejected(self):
         session = netsnmp.Session(**READ_ARGS)
         varlist = netsnmp.VarList(

--- a/netsnmp/tests/system/test_v1.py
+++ b/netsnmp/tests/system/test_v1.py
@@ -24,6 +24,13 @@ class SnmpV1Tests(unittest.TestCase):
             netsnmp.Varbind(SYS_DESCR, '0'), **V1_READ_ARGS)
         assert_value(self, values)
 
+    def test_get_unknown_instance_returns_no_value(self):
+        varbind = netsnmp.Varbind(SYS_DESCR, '123')
+
+        self.assertEqual(netsnmp.snmpget(varbind, **V1_READ_ARGS), (None,))
+        self.assertIsNone(varbind.val)
+        self.assertIsNone(varbind.type)
+
     def test_getnext(self):
         values = netsnmp.snmpgetnext(
             netsnmp.Varbind(SYSTEM), **V1_READ_ARGS)


### PR DESCRIPTION
## Summary

Return `None` instead of an empty byte string when an SNMPv1 GET requests a non-existing instance.

This ports the upstream Net-SNMP fix for [net-snmp/net-snmp#414](https://github.com/net-snmp/net-snmp/issues/414), implemented upstream in commit [`b33d6bbe`](https://github.com/net-snmp/net-snmp/commit/b33d6bbe72b26a5b2a8cced96178c6de1105181f).

This PR supersedes #9 with a minimal patch based on the current master branch and adds coverage to the active system-test suite.

## Root cause

For SNMPv1, a missing instance is reported through `err_ind`. The response still contains a varbind that was being processed as an `OCTETSTR`, producing `b''`.

This is indistinguishable from a valid empty string value.

## Changes

- Skip GET response varbind processing at and after the SNMPv1 error index.
- Leave affected tuple entries and `Varbind` values as `None`.
- Add an SNMPv1 regression test for a known OID with a non-existing IID.
- Add corresponding SNMPv2c coverage.
- Preserve the existing test for a completely unknown OID.

## Behavior

Before:

- SNMPv1 GET for `sysDescr.123` returned `(b'',)`.

After:

- SNMPv1 GET for `sysDescr.123` returns `(None,)`.
- The affected `Varbind.val` and `Varbind.type` remain `None`.

## Testing

- 41 system tests passed.
- ASan/UBSan passed with no reported errors.
- Valgrind passed with:
  - 0 bytes definitely lost
  - 0 bytes indirectly lost
  - 0 bytes possibly lost
  - 0 errors
- `git diff --check` passed.