### PR TITLE
Update GitHub Actions versions and gitignores

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: sh netsnmp/tests/system/run-coverage.sh
 
       - name: Upload C coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: client-intf-coverage
           path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
       # gives us net-snmp-config on PATH, which setup.py relies on.
       - name: Cache net-snmp install
         id: cache-netsnmp
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ runner.temp }}\msys64\mingw64\bin\net-snmp-config

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 build/
 dist/
+.vscode/
 __pycache__/
 *.py[co]
+*.so
+*.gcov
+client_intf-coverage.txt
 .*.swp
 .*.swo
 *.egg-info/


### PR DESCRIPTION
## Summary

Update outdated GitHub Actions dependencies

## Changes

- Update `actions/upload-artifact` from v4 to v7.
- Update `actions/cache` from v4 to v6.
- Ignore local VS Code settings.
- Ignore generated native-extension and C coverage artifacts.

## Testing

- Validated all workflows with `actionlint`.
- Validated workflow YAML with `yamllint`.
- Ran 44 system tests successfully.
- Ran all 44 system tests under Valgrind with no errors or lost memory.
- Ran all 44 system tests under ASan and UBSan with no sanitizer errors.
- Generated the C coverage report successfully with 59.93% line coverage.